### PR TITLE
ExpectTypeSnapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,32 @@ foo(2); // $ExpectType void
 foo("bar");
 ```
 
+# Adding $ExpectTypeSnapshot
+
+Uses snapshot saved in file as expected type for expression.
+
+Example:
+
+**foo.test.ts**
+```ts
+// $ExpectTypeSnapshot Foo
+const Foo = {
+  a: 1,
+  n: 17,
+} as const;
+```
+
+By running `eslint --fix` the following file will be created in the folder of `foo.test.ts`:
+**__type-snapshots__/foo.test.ts.snap.json**
+
+By running `eslint` snapshot type will be matched with actual type and Error will be emitted in case types don't match.
+
+## To create/update snapshots:
+
+```sh
+eslint --fix
+```
+
 # References
 
 1. https://github.com/gcanti/dtslint

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "eslint-plugin-expect-type",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,19 @@
             "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
             "dev": true
         },
+        "@types/fs-extra": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.0.0.tgz",
+            "integrity": "sha512-bCtL5v9zdbQW86yexOlXWTEGvLNqWxMFyi7gQA7Gcthbezr2cPSOb8SkESVKA937QD5cIwOFLDFt0MQoXOEr9Q==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@types/json-schema": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
-            "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
-            "dev": true
+            "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A=="
         },
         "@types/node": {
             "version": "12.7.4",
@@ -39,7 +47,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.1.0.tgz",
             "integrity": "sha512-ZJGLYXa4nxjNzomaEk1qts38B/vludg2LOM7dRc7SppEKsMPTS1swaTKS/pom+x4d/luJGoG00BDIss7PR1NQA==",
-            "dev": true,
             "requires": {
                 "@types/json-schema": "^7.0.3",
                 "@typescript-eslint/typescript-estree": "2.1.0",
@@ -62,7 +69,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.1.0.tgz",
             "integrity": "sha512-482ErJJ7QYghBh+KA9G+Fwcuk/PLTy+9NBMz8S+6UFrUUnVvHRNAL7I70kdws2te0FBYEZW7pkDaXoT+y8UARw==",
-            "dev": true,
             "requires": {
                 "glob": "^7.1.4",
                 "is-glob": "^4.0.1",
@@ -73,14 +79,12 @@
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-            "dev": true
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -89,14 +93,12 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-            "dev": true
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "eslint-scope": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
             "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
-            "dev": true,
             "requires": {
                 "esrecurse": "^4.1.0",
                 "estraverse": "^4.1.1"
@@ -121,7 +123,6 @@
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
             "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
-            "dev": true,
             "requires": {
                 "estraverse": "^4.1.0"
             }
@@ -129,14 +130,22 @@
         "estraverse": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-            "dev": true
+            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+        },
+        "fs-extra": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+            "requires": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            }
         },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-            "dev": true
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "functional-red-black-tree": {
             "version": "1.0.1",
@@ -148,7 +157,6 @@
             "version": "7.1.4",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
             "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-            "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -158,11 +166,15 @@
                 "path-is-absolute": "^1.0.0"
             }
         },
+        "graceful-fs": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+            "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
+        },
         "inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-            "dev": true,
             "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -171,35 +183,38 @@
         "inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-            "dev": true
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
         },
         "is-glob": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
             "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-            "dev": true,
             "requires": {
                 "is-extglob": "^2.1.1"
+            }
+        },
+        "jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "requires": {
+                "graceful-fs": "^4.1.6"
             }
         },
         "lodash.unescape": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
-            "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
-            "dev": true
+            "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw="
         },
         "minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -208,7 +223,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -216,8 +230,7 @@
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "prettier": {
             "version": "1.18.2",
@@ -234,8 +247,7 @@
         "semver": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "dev": true
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         },
         "tslib": {
             "version": "1.10.0",
@@ -255,14 +267,17 @@
         "typescript": {
             "version": "3.6.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz",
-            "integrity": "sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==",
-            "dev": true
+            "integrity": "sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw=="
+        },
+        "universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
         },
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,30 +1,34 @@
 {
-    "name": "eslint-plugin-expect-type",
-    "version": "0.0.1",
-    "description": "ESLint plugin with $ExpectType and $ExpectError type assertions",
-    "main": "dist/index.js",
-    "license": "Apache-2.0",
-    "repository": {
-      "type": "git",
-      "url": "git+https://github.com/ibezkrovnyi/eslint-plugin-expect-type.git"
-    },
-    "devDependencies": {
-        "@types/node": "^12.7.2",
-        "@typescript-eslint/eslint-plugin": "^2.0.0",
-        "@typescript-eslint/experimental-utils": "^2.0.0",
-        "@typescript-eslint/parser": "^2.0.0",
-        "tsutils": "^3.17.1",
-        "typescript": "^3.5.3",
-        "prettier": "^1.18.2"
-    },
-    "engines": {
-        "node": ">=10.3.0"
-    },
-    "scripts": {
-        "build": "tsc",
-        "prepublishOnly": "tsc"
-    },
-    "files": [
-        "dist"
-    ]
+  "name": "eslint-plugin-expect-type",
+  "version": "0.0.1",
+  "description": "ESLint plugin with $ExpectType and $ExpectError type assertions",
+  "main": "dist/index.js",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ibezkrovnyi/eslint-plugin-expect-type.git"
+  },
+  "dependencies": {
+    "@typescript-eslint/experimental-utils": "^2.0.0",
+    "fs-extra": "^8.1.0",
+    "typescript": "^3.5.3"
+  },
+  "devDependencies": {
+    "@types/fs-extra": "^8.0.0",
+    "@types/node": "^12.7.2",
+    "@typescript-eslint/eslint-plugin": "^2.0.0",
+    "@typescript-eslint/parser": "^2.0.0",
+    "prettier": "^1.18.2",
+    "tsutils": "^3.17.1"
+  },
+  "engines": {
+    "node": ">=10.3.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "prepublishOnly": "tsc"
+  },
+  "files": [
+    "dist"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-expect-type",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "ESLint plugin with $ExpectType and $ExpectError type assertions",
   "main": "dist/index.js",
   "license": "Apache-2.0",

--- a/src/utils/snapshot.ts
+++ b/src/utils/snapshot.ts
@@ -1,0 +1,33 @@
+import { dirname, resolve, basename } from 'path';
+import { ensureFileSync, readJsonSync, writeJsonSync } from 'fs-extra';
+
+export const getTypeSnapshot = (filename: string, snapshotName: string) => {
+  const snapshotPath = getSnapshotPath(filename);
+  const json = readJsonSync(snapshotPath, { throws: false });
+  if (!json) {
+    return;
+  }
+  return json[snapshotName] as string;
+};
+
+export const updateTypeSnapshot = (
+  filename: string,
+  snapshotName: string,
+  actualType: string,
+) => {
+  const snapshotPath = getSnapshotPath(filename);
+  ensureFileSync(snapshotPath)
+
+  const json = readJsonSync(snapshotPath, { throws: false }) || {};
+  json[snapshotName] = actualType;
+  writeJsonSync(snapshotPath, json);
+};
+
+function getSnapshotPath(filename: string) {
+  const directory = dirname(filename);
+  return resolve(
+    directory,
+    '__type-snapshots__',
+    `${basename(filename)}.snap.json`,
+  );
+}


### PR DESCRIPTION
Supports `--fix` - updates/creates snapshot

**foo.test.ts**
```ts
// $ExpectTypeSnapshot Foo
const Foo = {
  a: 1,
  n: 17,
} as const;
```

The following file will be created in the same folder:
`__type-snapshots__/foo.test.ts.snap.json`