### PR TITLE
Use options with defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,17 @@ Rule severity could be configured as follows
 ```json
 {
   "rules": {
-    "expect-type/rule": "error"
+    "expect-type/expect": "error"
+  }
+}
+```
+
+To skip Snapshot update when eslint is run with `--fix` could be configured as follows:
+
+```json
+{
+  "rules": {
+    "expect-type/expect": ["error", { "disableExpectTypeSnapshotFix": true }]
   }
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-expect-type",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-expect-type",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "ESLint plugin with $ExpectType, $ExpectError and $ExpectTypeSnapshot type assertions",
   "author": {
     "name": "Igor Bezkrovnyi"

--- a/src/rules/expect.ts
+++ b/src/rules/expect.ts
@@ -189,7 +189,7 @@ function validate(context: TSESLint.RuleContext<MessageIds, [Options]>, options:
             if (!applied) {
               // Make sure we update snapshot only on first read of this object
               applied = true;
-              if (!context.options[0].disableExpectTypeSnapshotFix) {
+              if (!options.disableExpectTypeSnapshotFix) {
                 updateTypeSnapshot(fileName, snapshotName, actual);
               }
             }

--- a/src/rules/expect.ts
+++ b/src/rules/expect.ts
@@ -8,14 +8,14 @@ import { getTypeSnapshot, updateTypeSnapshot } from '../utils/snapshot';
 import { RuleFix } from '@typescript-eslint/experimental-utils/dist/ts-eslint';
 
 const messages = {
-  TypeScriptCompileError: 'TypeScript compile error:\n{{ message }}',
+  TypeScriptCompileError: 'TypeScript compile error: {{ message }}',
   FileIsNotIncludedInTsconfig: 'Expected to find a file "{{ fileName }}" present.',
-  TypesDoNotMatch: 'Expected type to be:\n  {{ expected }}\ngot:\n  {{ actual }}',
+  TypesDoNotMatch: 'Expected type to be: {{ expected }}, got: {{ actual }}',
   OrphanAssertion: 'Can not match a node to this assertion.',
   Multiple$ExpectTypeAssertions: 'This line has 2 or more $ExpectType assertions.',
   ExpectedErrorNotFound: 'Expected an error on this line, but found none.',
   TypeSnapshotNotFound: 'Type Snapshot not found. Please consider running ESLint in FIX mode: eslint --fix',
-  TypeSnapshotDoNotMatch: 'Expected type from Snapshot to be:\n  {{ expected }}\ngot:\n  {{ actual }}',
+  TypeSnapshotDoNotMatch: 'Expected type from Snapshot to be: {{ expected }}, got: {{ actual }}',
   SyntaxError: 'Syntax Error: {{ message }}',
 };
 type MessageIds = keyof typeof messages;


### PR DESCRIPTION
Use options with merged defaults provided by `createRule` instead of `context.options` which only has configured by user options.

Update README.md (rule was renamed in previous build to `expect-type/expect`)

Resolves #10 